### PR TITLE
Feature: dynamic cunsumption rates

### DIFF
--- a/client/init.lua
+++ b/client/init.lua
@@ -1,9 +1,12 @@
 local config = require 'config'
+local vehicles = require 'data.vehicles'
 
 if not config then return end
 
 SetFuelConsumptionState(true)
-SetFuelConsumptionRateMultiplier(config.globalFuelConsumptionRate)
+if config.globalFuelConsumptionRate then
+	SetFuelConsumptionRateMultiplier(config.globalFuelConsumptionRate)
+end
 
 AddTextEntry('fuelHelpText', locale('fuel_help'))
 AddTextEntry('petrolcanHelpText', locale('petrolcan_help'))
@@ -18,6 +21,7 @@ require 'client.stations'
 
 local function startDrivingVehicle()
 	local vehicle = cache.vehicle
+	local vehicleModel = GetEntityModel(vehicle)
 
 	if not DoesVehicleUseFuel(vehicle) then return end
 
@@ -28,6 +32,16 @@ local function startDrivingVehicle()
 		while not vehState.fuel do Wait(0) end
 	end
 
+	-- Create locallized value for the thread to define the consumptionRate
+	local consumptionRate = config.globalFuelConsumptionRate
+	if type(vehicles.models[vehicleModel]) == 'number' then
+		consumptionRate = vehicles.models[vehicleModel]
+	else
+		local class = GetVehicleClass(vehicle)
+
+		consumptionRate = vehicles[class]
+	end
+
 	SetVehicleFuelLevel(vehicle, vehState.fuel)
 
 	local fuelTick = 0
@@ -35,7 +49,7 @@ local function startDrivingVehicle()
 	while cache.seat == -1 do
 		if GetIsVehicleEngineRunning(vehicle) then
 			if not DoesEntityExist(vehicle) then return end
-			SetFuelConsumptionRateMultiplier(config.globalFuelConsumptionRate)
+			SetFuelConsumptionRateMultiplier(consumptionRate)
 
 			local fuelAmount = tonumber(vehState.fuel)
 			local newFuel = GetVehicleFuelLevel(vehicle)

--- a/config.lua
+++ b/config.lua
@@ -38,7 +38,8 @@ return {
 		refillPrice = 800,
 	},
 
-	---Modifies the fuel consumption rate of all vehicles - see [`SET_FUEL_CONSUMPTION_RATE_MULTIPLIER`](https://docs.fivem.net/natives/?_0x845F3E5C).
+	-- Setting this to a number, will use a global rate for all vehicles, setting it to false will use the data in `data/vehicles.lua`
+	-- Modifies the fuel consumption rate of all vehicles - see [`SET_FUEL_CONSUMPTION_RATE_MULTIPLIER`](https://docs.fivem.net/natives/?_0x845F3E5C).
 	globalFuelConsumptionRate = 10.0,
 
 	-- Gas pump models

--- a/data/vehicles.lua
+++ b/data/vehicles.lua
@@ -24,5 +24,8 @@ return {
 	models = {
 		[GetHashKey('tug')] = 14.0,
 		[GetHashKey('kosatka')] = 16.0,
+		[GetHashKey('seashark')] = 3.0,
+		[GetHashKey('seashark2')] = 3.0,
+		[GetHashKey('seashark3')] = 3.0,
 	},
 }

--- a/data/vehicles.lua
+++ b/data/vehicles.lua
@@ -1,0 +1,28 @@
+return {
+	-- Modifies the fuel consumption rate of all vehicles
+	-- see [`SET_FUEL_CONSUMPTION_RATE_MULTIPLIER`](https://docs.fivem.net/natives/?_0x845F3E5C).
+	[0] = 9.0,		-- Compact
+	[1] = 10.0,		-- Sedan
+	[2] = 11.0,		-- SUV
+	[3] = 10.0,		-- Coupe
+	[4] = 12.0,		-- Muscle
+	[5] = 11.5,		-- Sports Classic
+	[6] = 12.5,		-- Sports
+	[7] = 14.0,		-- Super
+	[8] = 7.0,		-- Motorcycle
+	[9] = 11.5,		-- Offroad
+	[10] = 13.0,	-- Industrial
+	[11] = 11.0,	-- Utility
+	[12] = 10.5,	-- Van
+	[14] = 6.0,		-- Boat
+	[15] = 15.0,	-- Helicopter
+	[16] = 16.0,	-- Plane
+	[17] = 10.5,	-- Service
+	[18] = 9.0,		-- Emergency
+	[19] = 13.5,	-- Military
+	[20] = 14.5,	-- Commercial (trucks)
+	models = {
+		[GetHashKey('tug')] = 14.0,
+		[GetHashKey('kosatka')] = 16.0,
+	},
+}

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -27,7 +27,7 @@ client_script 'client/init.lua'
 
 files {
 	'locales/*.json',
-	'data/stations.lua',
+	'data/*.lua',
 	'client/*.lua',
 }
 


### PR DESCRIPTION
This PR reflects the issue where not all vehicles have predefined consumption rates, this issue is less of one when using global consumption rate modifier and "overriding" the maximum volume of vehicle fuel tanks (not all vehicles have 100L tanks).

For a comparison, the seasharks only have a fuel volume of 2L compared to the average vehicle that has 65L, in both cases if fully refuelled with the current ox_fuel version (v1.5.2), every vehicle will have a tank of 100L and the exact same consumption rate. This PR adds more dynamics to it making vehicles consume more or less fuel depending initially on their class, or if having a specific rule the defined value.
The logic used for this is the same as for vehicle trunks/gloveboxes within ox_inventory.

Alone this PR is not as useful as some vehicles would seem to never run out of fuel (i.e. any vehicle using a rate less then 5), in addition to this one I would also suggest having ox_fuel not override fuel capacity for all vehicles and use their predetermined fuel volume as set within their `handling.meta` behaviour. For this I already have a branch ( [`refactor/percentage-to-volume-fuel`](https://github.com/Maximus7474/ox_fuel/tree/refactor/percentage-to-volume-fuel) ) that is ready to merge accomplishing this.

Some minor tests would be needed, and possible merges but I'll do those accordingly if this is of interest, which I hope it is being that it enhances functionality of ox_fuel making it more complete.